### PR TITLE
Fix UI bug

### DIFF
--- a/app/src/main/java/ca/wheresthebus/MainActivity.kt
+++ b/app/src/main/java/ca/wheresthebus/MainActivity.kt
@@ -18,6 +18,7 @@ import ca.wheresthebus.databinding.ActivityMainBinding
 import ca.wheresthebus.service.NfcService
 import com.google.android.material.navigation.NavigationBarView
 import android.Manifest
+import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.lifecycleScope
 import ca.wheresthebus.utils.Utils
 import kotlinx.coroutines.Dispatchers
@@ -30,6 +31,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,8 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="?attr/actionBarSize"
+    android:fitsSystemWindows="true"
+    android:windowSoftInputMode="adjustResize"
     >
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
@@ -27,7 +28,6 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginBottom="16dp"
-        android:layout_marginTop="?actionBarSize"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/nav_view"
         app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION
ISSUE: 
The padding when dealing with the action/app bar was inconsistent. When testing for some API versions, it was appearing behind the action/app bars, and for others, it was appearing properly below the action bar.

WHY:
Upon research, it seems that this is an issue related to API versions 34 and below VS. API versions 35 and above. See here: https://developer.android.com/develop/ui/compose/layouts/insets. Basically, WindowInsets are now the new standard and there is no automatic padding for newer API versions to adhere to layout changes.

FIX:
Instead of manually adding padding which only works for newer API versions while lower API versions get pushed further down, use `enableEdgeToEdge()` which sets up WindowInsets. This can differentiate between API version on whether to apply the padding or not.