### PR TITLE
Fix route shortname adapter bug

### DIFF
--- a/app/src/main/java/ca/wheresthebus/adapter/StopSuggestionAdapter.kt
+++ b/app/src/main/java/ca/wheresthebus/adapter/StopSuggestionAdapter.kt
@@ -26,79 +26,73 @@ class StopSuggestionAdapter(
     private val context: Context
 ) : RecyclerView.Adapter<StopSuggestionAdapter.SuggestedStopViewHolder>() {
 
-    inner class SuggestedStopViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    inner class SuggestedStopViewHolder(var view: View) : RecyclerView.ViewHolder(view) {
         private val stopName: TextView = view.findViewById(R.id.suggested_stop_name)
         private val stopCode: TextView = view.findViewById(R.id.suggested_stop_code)
         private val routesAtStop: TextView = view.findViewById(R.id.suggested_stop_routes)
+
         // Key is the route short name
-        private val routesMap: MutableMap<String, Route> = mutableMapOf()
+        private var customView: View =
+            LayoutInflater.from(view.context).inflate(R.layout.dialog_add_fav_stop, null)
+        private val nicknameEditText: EditText = customView.findViewById(R.id.nicknameEditText)
+        private val routesSpinner: Spinner = customView.findViewById(R.id.routeChoiceSpinner)
 
         fun bind(stop: BusStop) {
             stopName.text = stop.name
             stopCode.text = stop.code.value
 
-            // Clear old content
-            routesMap.clear()
-            routesAtStop.text = ""
-
-            stop.routes.forEach { routesMap[it.shortName] = it }
+            val routesMap = stop.routes.associateBy { it.shortName }
             routesAtStop.text = routesMap.keys.joinToString(", ")
-        }
 
-        init {
-            view.setOnClickListener {
-                val selectedStop = suggestedStops[adapterPosition]
-                val builder = AlertDialog.Builder(view.context)
-                val customView = LayoutInflater.from(view.context).inflate(R.layout.dialog_add_fav_stop, null)
-                builder.setView(customView)
+            var selectedRoute: Route? = null
 
-                val nicknameEditText: EditText = customView.findViewById(R.id.nicknameEditText)
-                val routesSpinner: Spinner = customView.findViewById(R.id.routeChoiceSpinner)
-
-                val routesAdapter = ArrayAdapter(context, R.layout.route_spinner_item, routesMap.keys.toList())
-                var selectedRoute: Route? = null
-
-                routesSpinner.adapter = routesAdapter
-                routesSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-                    override fun onItemSelected(
-                        parent: AdapterView<*>,
-                        view: View?,
-                        position: Int,
-                        id: Long
-                    ) {
-                        val key = routesSpinner.adapter.getItem(position)
-                        selectedRoute = routesMap[key]
-                    }
-                    override fun onNothingSelected(parent: AdapterView<*>) {
-                        selectedRoute = null
-                    }
+            routesSpinner.adapter = ArrayAdapter(context, R.layout.route_spinner_item, routesMap.keys.toList())
+            routesSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(
+                    parent: AdapterView<*>, view: View?, position: Int, id: Long
+                ) {
+                    val key = routesSpinner.adapter.getItem(position)
+                    selectedRoute = routesMap[key]
                 }
 
+                override fun onNothingSelected(parent: AdapterView<*>) {
+                    selectedRoute = null
+                }
+            }
+
+            view.setOnClickListener {
+                val selectedStop = suggestedStops[adapterPosition]
+                val builder = AlertDialog.Builder(customView.context)
+
                 // Creating dialog
-                builder.setTitle("Add Favourite Stop").setNegativeButton("Cancel") { _, _ ->
-                    // Do nothing on cancel
-                }.setPositiveButton("Ok") { _, _ ->
-                    if (selectedRoute != null) {
-                        val newFavouriteStop = FavouriteStop(
-                            nicknameEditText.text.toString(),
-                            selectedStop,
-                            selectedRoute!!
-                        )
-                        mainDBViewModel.insertFavouriteStop(newFavouriteStop)
-                    } else {
-                        Toast.makeText(
-                            view.context,
-                            "Please select a valid bus route.",
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
-                }.create().show()
+                builder
+                    .setView(customView)
+                    .setTitle("Add Favourite Stop")
+                    .setNegativeButton("Cancel") { _, _ -> }
+                    .setPositiveButton("Ok") { _, _ ->
+                        if (selectedRoute != null) {
+                            mainDBViewModel.insertFavouriteStop(
+                                FavouriteStop(
+                                    nicknameEditText.text.toString(),
+                                    selectedStop,
+                                    selectedRoute!!
+                                )
+                            )
+                        } else {
+                            Toast.makeText(
+                                view.context,
+                                "Please select a valid bus route.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }.create().show()
             }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SuggestedStopViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_suggested_bus, parent, false)
+        val view =
+            LayoutInflater.from(parent.context).inflate(R.layout.item_suggested_bus, parent, false)
         return SuggestedStopViewHolder(view)
     }
 


### PR DESCRIPTION
routeShortNames list was being overwritten whenever adapter view is initialized. Moved it down so each view holder maintains its own list of routes.

Changed from list of strings to map<shortName, route> to remove db call on spinner selection