### PR TITLE
Implement NearbyBus with favourites

### DIFF
--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyBottomSheet.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyBottomSheet.kt
@@ -11,7 +11,7 @@ import ca.wheresthebus.data.model.BusStop
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class NearbyBottomSheet(private val stops: List<BusStop>) : BottomSheetDialogFragment() {
+class NearbyBottomSheet(private val stops: List<BusStop>) : BottomSheetDialogFragment(), NearbyStopSavedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.bottom_sheet_nearby, container, false)
@@ -32,6 +32,10 @@ class NearbyBottomSheet(private val stops: List<BusStop>) : BottomSheetDialogFra
 
         val recyclerView: RecyclerView = dialog!!.findViewById(R.id.nearby_stops_recycler_view)
         recyclerView.layoutManager = LinearLayoutManager(context)
-        recyclerView.adapter = NearbyStopsAdapter(stops)
+        recyclerView.adapter = NearbyStopsAdapter(requireActivity(), stops, this)
+    }
+
+    override fun onStopSaved() {
+        this.dismiss()
     }
 }

--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopSavedListener.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopSavedListener.kt
@@ -1,0 +1,9 @@
+package ca.wheresthebus.ui.nearby
+
+/**
+ * Listener for the NearbyBottomSheet to know if an item was saved
+ * so that it can dismiss itself
+ */
+interface NearbyStopSavedListener {
+    fun onStopSaved()
+}

--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
@@ -1,18 +1,40 @@
 package ca.wheresthebus.ui.nearby
 
+import android.app.AlertDialog
+import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
 import android.widget.Button
+import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.RecyclerView
+import ca.wheresthebus.MainDBViewModel
 import ca.wheresthebus.R
 import ca.wheresthebus.data.model.BusStop
+import ca.wheresthebus.data.model.FavouriteStop
+import ca.wheresthebus.data.model.Route
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputLayout
 
-class NearbyStopsAdapter(private val stops: List<BusStop>) : RecyclerView.Adapter<NearbyStopsAdapter.ViewHolder>() {
+class NearbyStopsAdapter(
+    private val activity: FragmentActivity,
+    private val stops: List<BusStop>,
+    private val onItemSavedListener: NearbyStopSavedListener
+) : RecyclerView.Adapter<NearbyStopsAdapter.ViewHolder>() {
 
     private var expandedPosition: Int = RecyclerView.NO_POSITION
+    private val mainDBViewModel: MainDBViewModel by lazy {
+        ViewModelProvider(activity).get(MainDBViewModel::class.java)
+    }
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val stopNickname: TextView = view.findViewById(R.id.NearbyBottomSheet_stopNickname)
@@ -43,6 +65,69 @@ class NearbyStopsAdapter(private val stops: List<BusStop>) : RecyclerView.Adapte
             notifyItemChanged(previousExpandedPosition)
             notifyItemChanged(expandedPosition)
         }
+
+        holder.saveButton.setOnClickListener {
+            onSaveButtonClick(position)
+        }
+    }
+
+    private fun onSaveButtonClick(position: Int) {
+        val busStop: BusStop = stops[position]
+        val routesMap = busStop.routes.associateBy { it.shortName }
+
+        val customView =
+            LayoutInflater.from(activity).inflate(R.layout.dialog_add_fav_stop, null)
+        val nicknameEditText: EditText = customView.findViewById(R.id.nicknameEditText)
+        val routesDropdown: AutoCompleteTextView = customView.findViewById(R.id.routes_dropdown)
+        val routesDropdownLayout: TextInputLayout = customView.findViewById(R.id.routes_dropdown_layout)
+
+        // set dropdown content
+        val routesAdapter =
+            ArrayAdapter(activity, R.layout.route_spinner_item, routesMap.keys.toList())
+        routesDropdown.setAdapter(routesAdapter)
+
+        // Grab selected dropdown option
+        var selectedRoute: Route? = null
+        routesDropdown.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun afterTextChanged(s: Editable?) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                selectedRoute = routesMap[s.toString()]
+            }
+        })
+
+        // Build the dialog
+        val dialog = MaterialAlertDialogBuilder(activity)
+            .setView(customView)
+            .setTitle("Adding New Favourite Stop")
+            .setMessage(busStop.name)
+            .setNegativeButton("Cancel") { dialog, _ -> dialog.dismiss() }
+            .setPositiveButton("Confirm", null)
+            .create()
+
+        // override OK to check valid dropdown selections
+        dialog.setOnShowListener {
+            val confirmButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            confirmButton.setOnClickListener {
+                if (selectedRoute != null) {
+                    routesDropdownLayout.error = null
+                    mainDBViewModel.insertFavouriteStop(
+                        FavouriteStop(
+                            nickname = nicknameEditText.text.toString(),
+                            busStop = busStop,
+                            route = selectedRoute!!
+                        )
+                    )
+                    dialog.dismiss() // dismiss this dialog
+                    onItemSavedListener.onStopSaved() // dismiss the bottom sheet fragment
+                    Toast.makeText(activity, "Added to favourites", Toast.LENGTH_SHORT).show()
+                } else {
+                    routesDropdownLayout.error = "Please select a valid bus route."
+                }
+            }
+        }
+
+        dialog.show()
     }
 
     override fun getItemCount() = stops.size

--- a/app/src/main/res/layout/item_nearby_bus.xml
+++ b/app/src/main/res/layout/item_nearby_bus.xml
@@ -40,18 +40,18 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Additional Information"
                 />
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:gravity="center_horizontal">
 
                 <Button
                     android:id="@+id/save_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Save to Favourites" />
+                    android:text="Add to Favourites" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>


### PR DESCRIPTION
Add favorite stops functionality with the nearby bus stop screen. The Listener was created so that the parent (BottomSheet) could dismiss itself when a stop was added.

Also added a Toast message when a stop was added to make it clear that it worked, but is kinda inconsistent with the home page add favourite because it has no Toast. 

![image](https://github.com/user-attachments/assets/8064059a-ca18-44ac-95cb-ed65fceccde0)
![image](https://github.com/user-attachments/assets/2ea1678d-b67a-4418-86f0-b2f68f159ed3)
![image](https://github.com/user-attachments/assets/78b4d590-6b05-4284-82ce-c75c74eaa670)
