### PR TITLE
Edit GTFS realtime, cleanup NearbyBottomSheet, remove warnings

### DIFF
--- a/app/src/main/java/ca/wheresthebus/adapter/FavStopAdapter.kt
+++ b/app/src/main/java/ca/wheresthebus/adapter/FavStopAdapter.kt
@@ -7,14 +7,14 @@ import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.recyclerview.widget.RecyclerView
 import ca.wheresthebus.R
-import ca.wheresthebus.data.StopCode
+import ca.wheresthebus.data.StopId
 import ca.wheresthebus.data.model.FavouriteStop
 import java.time.Duration
 
 class FavStopAdapter(
     private val dataSet: ArrayList<FavouriteStop>,
     private val type: Type = Type.HOME,
-    private val busTimesMap: MutableMap<StopCode, List<Duration>> = mutableMapOf()
+    private val busTimesMap: MutableMap<StopId, List<Duration>> = mutableMapOf()
 ) : RecyclerView.Adapter<FavStopAdapter.BindingFavStopHolder>() {
 
     enum class Type {
@@ -51,7 +51,7 @@ class FavStopAdapter(
                 append(stop.busStop.code.value)
             }
 
-            val busTimes = busTimesMap[stop.busStop.code]
+            val busTimes = busTimesMap[stop.busStop.id]
             if (!busTimes.isNullOrEmpty()) {
                 val formattedTimes = busTimes.map { busArrivalTime ->
                     val minutes = busArrivalTime.toMinutes()
@@ -120,7 +120,7 @@ class FavStopAdapter(
         }
     }
 
-    fun updateBusTimes(busTimes: Map<StopCode, List<Duration>>) {
+    fun updateBusTimes(busTimes: MutableMap<StopId, List<Duration>>) {
         busTimesMap.clear()
         busTimesMap.putAll(busTimes)
         notifyItemRangeChanged(0, itemCount)

--- a/app/src/main/java/ca/wheresthebus/service/GtfsRealtimeHelper.kt
+++ b/app/src/main/java/ca/wheresthebus/service/GtfsRealtimeHelper.kt
@@ -25,22 +25,15 @@ class GtfsRealtimeHelper {
         private val client = OkHttpClient()
         private const val GTFS_API_URL = "https://gtfsapi.translink.ca/v3/gtfsrealtime?apikey=${ca.wheresthebus.BuildConfig.GTFS_KEY}"
 
-        suspend fun getBusTimes(stopsInfo: List<Pair<StopId, RouteId>>): List<List<Duration>> {
+        suspend fun getBusTimes(stopsInfo: List<Pair<StopId, RouteId>>): MutableMap<StopId, List<Duration>> {
             return try {
                 val feedMessage = callGtfsRealtime()
-                stopsInfo.map { (stopId, routeId) ->
-                    try {
-                        val busTimes = grabBusTimes(feedMessage, stopId, routeId)
-                        convertBusTimes(busTimes)
-                    } catch (e: Exception) {
-                        Log.e("GTFS", "Error fetching bus times", e)
-                        emptyList()
-                    }
-                }
-
+                stopsInfo.associate { (stopId, routeId) ->
+                    stopId to convertBusTimes(grabBusTimes(feedMessage, stopId, routeId))
+                }.toMutableMap()
             } catch (e: Exception) {
                 Log.e("GTFS", "Error fetching GTFS realtime data", e)
-                emptyList()
+                mutableMapOf<StopId, List<Duration>>()
             }
         }
 

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
@@ -19,12 +19,14 @@ import ca.wheresthebus.R
 import ca.wheresthebus.adapter.FavStopAdapter
 import ca.wheresthebus.data.ModelFactory
 import ca.wheresthebus.data.RouteId
+import ca.wheresthebus.data.StopCode
 import ca.wheresthebus.data.StopId
 import ca.wheresthebus.data.model.FavouriteStop
 import ca.wheresthebus.databinding.FragmentHomeBinding
 import ca.wheresthebus.service.GtfsRealtimeHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.Duration
 
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
@@ -166,10 +168,11 @@ class HomeFragment : Fragment() {
                 }
                 val busTimesLists = GtfsRealtimeHelper.getBusTimes(stopRoutePairs)
 
-                // Create a map of stop codes to their next bus times
-                val busTimesMap = favouriteStopsList.mapIndexed { index, stop ->
-                    stop.busStop.code to busTimesLists[index]
-                }.toMap()
+                // Create a mutableMap of stop codes to their next bus times
+                val busTimesMap = mutableMapOf<StopCode, List<Duration>>()
+                for (i in busTimesLists.indices) {
+                    busTimesMap[favouriteStopsList[i].busStop.code] = busTimesLists[i]
+                }
 
                 lifecycleScope.launch(Dispatchers.Main) {
                     homeViewModel.busTimes.value = busTimesMap

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
@@ -19,14 +19,12 @@ import ca.wheresthebus.R
 import ca.wheresthebus.adapter.FavStopAdapter
 import ca.wheresthebus.data.ModelFactory
 import ca.wheresthebus.data.RouteId
-import ca.wheresthebus.data.StopCode
 import ca.wheresthebus.data.StopId
 import ca.wheresthebus.data.model.FavouriteStop
 import ca.wheresthebus.databinding.FragmentHomeBinding
 import ca.wheresthebus.service.GtfsRealtimeHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.time.Duration
 
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
@@ -166,13 +164,8 @@ class HomeFragment : Fragment() {
                 val stopRoutePairs = favouriteStopsList.map { stop ->
                     StopId(stop.busStop.id.value) to RouteId(stop.route.id.value)
                 }
-                val busTimesLists = GtfsRealtimeHelper.getBusTimes(stopRoutePairs)
 
-                // Create a mutableMap of stop codes to their next bus times
-                val busTimesMap = mutableMapOf<StopCode, List<Duration>>()
-                for (i in busTimesLists.indices) {
-                    busTimesMap[favouriteStopsList[i].busStop.code] = busTimesLists[i]
-                }
+                val busTimesMap = GtfsRealtimeHelper.getBusTimes(stopRoutePairs)
 
                 lifecycleScope.launch(Dispatchers.Main) {
                     homeViewModel.busTimes.value = busTimesMap

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeFragment.kt
@@ -19,14 +19,12 @@ import ca.wheresthebus.R
 import ca.wheresthebus.adapter.FavStopAdapter
 import ca.wheresthebus.data.ModelFactory
 import ca.wheresthebus.data.RouteId
-import ca.wheresthebus.data.StopCode
 import ca.wheresthebus.data.StopId
 import ca.wheresthebus.data.model.FavouriteStop
 import ca.wheresthebus.databinding.FragmentHomeBinding
 import ca.wheresthebus.service.GtfsRealtimeHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.time.Duration
 
 class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
@@ -162,14 +160,16 @@ class HomeFragment : Fragment() {
     private fun refreshBusTimes() {
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                // Create a map of favourite stops to their next bus times
-                val busTimesMap = mutableMapOf<StopCode, List<Duration>>()
-                favouriteStopsList.forEach { stop ->
-                    val nextBusTimes = GtfsRealtimeHelper.getBusTimes(
-                        StopId(stop.busStop.id.value),
-                        RouteId(stop.route.id.value))
-                    busTimesMap[stop.busStop.code] = nextBusTimes
+                // Convert all favorite stops to pairs list and do GTFS realtime call
+                val stopRoutePairs = favouriteStopsList.map { stop ->
+                    StopId(stop.busStop.id.value) to RouteId(stop.route.id.value)
                 }
+                val busTimesLists = GtfsRealtimeHelper.getBusTimes(stopRoutePairs)
+
+                // Create a map of stop codes to their next bus times
+                val busTimesMap = favouriteStopsList.mapIndexed { index, stop ->
+                    stop.busStop.code to busTimesLists[index]
+                }.toMap()
 
                 lifecycleScope.launch(Dispatchers.Main) {
                     homeViewModel.busTimes.value = busTimesMap

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
@@ -13,5 +13,5 @@ class HomeViewModel : ViewModel() {
     }
     val text: LiveData<String> = _text
 
-    val busTimes =  MutableLiveData<Map<StopCode, List<Duration>>>()
+    val busTimes =  MutableLiveData<MutableMap<StopCode, List<Duration>>>()
 }

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
@@ -3,7 +3,7 @@ package ca.wheresthebus.ui.home
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import ca.wheresthebus.data.StopCode
+import ca.wheresthebus.data.StopId
 import java.time.Duration
 
 class HomeViewModel : ViewModel() {
@@ -13,5 +13,5 @@ class HomeViewModel : ViewModel() {
     }
     val text: LiveData<String> = _text
 
-    val busTimes =  MutableLiveData<MutableMap<StopCode, List<Duration>>>()
+    val busTimes =  MutableLiveData<MutableMap<StopId, List<Duration>>>()
 }

--- a/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/HomeViewModel.kt
@@ -13,5 +13,5 @@ class HomeViewModel : ViewModel() {
     }
     val text: LiveData<String> = _text
 
-    val busTimes =  MutableLiveData<MutableMap<StopCode, List<Duration>>>()
+    val busTimes =  MutableLiveData<Map<StopCode, List<Duration>>>()
 }

--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyBottomSheet.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyBottomSheet.kt
@@ -17,33 +17,33 @@ class NearbyBottomSheet(
 ) : BottomSheetDialogFragment(), NearbyStopSavedListener {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.bottom_sheet_nearby, container, false);
+        return inflater.inflate(R.layout.bottom_sheet_nearby, container, false)
     }
 
     override fun onStart() {
-        super.onStart();
-        val bottomSheet = dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet);
+        super.onStart()
+        val bottomSheet = dialog?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
         bottomSheet?.let {
-            val behavior = BottomSheetBehavior.from(it);
-            behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED;
+            val behavior = BottomSheetBehavior.from(it)
+            behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
 
             // adjust the bottom sheet height to be above the navigation bar
-            val layoutParams = it.layoutParams;
-            layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT;
-            it.layoutParams = layoutParams;
+            val layoutParams = it.layoutParams
+            layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            it.layoutParams = layoutParams
         }
 
-        val recyclerView: RecyclerView = dialog!!.findViewById(R.id.nearby_stops_recycler_view);
-        recyclerView.layoutManager = LinearLayoutManager(context);
-        val recyclerViewAdapter: NearbyStopsAdapter = NearbyStopsAdapter(requireActivity(), stops, this);
-        recyclerView.adapter = NearbyStopsAdapter(requireActivity(), stops, this);
+        val recyclerView: RecyclerView = dialog!!.findViewById(R.id.nearby_stops_recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        val recyclerViewAdapter = NearbyStopsAdapter(requireActivity(), stops, this)
+        recyclerView.adapter = NearbyStopsAdapter(requireActivity(), stops, this)
 
         // if there is a selected stop, scroll to it and expand it
         if (selectedStopId != null) {
-            val position = stops.indexOfFirst { stop -> stop.id.value == selectedStopId };
+            val position = stops.indexOfFirst { stop -> stop.id.value == selectedStopId }
             if (position != -1) { // if the stop is found
-                recyclerView.scrollToPosition(position);
-                recyclerViewAdapter.setExpandedPosition(position);
+                recyclerView.scrollToPosition(position)
+                recyclerViewAdapter.setExpandedPosition(position)
             }
         }
     }

--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
@@ -1,7 +1,6 @@
 package ca.wheresthebus.ui.nearby
 
 import android.app.AlertDialog
-import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -38,8 +37,7 @@ class NearbyStopsAdapter(
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val stopNickname: TextView = view.findViewById(R.id.NearbyBottomSheet_stopNickname)
-        val stopID: TextView = view.findViewById(R.id.NearbyBottomSheet_stopID)
-        val stopUpcoming: TextView = view.findViewById(R.id.NearbyBottomSheet_stopUpcoming)
+        val buses: TextView = view.findViewById(R.id.NearbyBottomSheet_buses)
         val extraInfo: LinearLayout = view.findViewById(R.id.extra_info)
         val saveButton: Button = view.findViewById(R.id.save_button)
     }
@@ -52,9 +50,13 @@ class NearbyStopsAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val stop = stops[position]
-        holder.stopNickname.text = stop.name
-        holder.stopID.text = stop.code.value
-        holder.stopUpcoming.text = "Upcoming Buses: NOT YET IMPLEMENTED"
+        holder.stopNickname.text = buildString {
+            append(stop.name)
+        }
+        holder.buses.text = buildString {
+            append("Buses: ")
+            append(stop.routes.joinToString(", ") { it.shortName })
+        }
 
         val isExpanded = position == expandedPosition
         holder.extraInfo.visibility = if (isExpanded) View.VISIBLE else View.GONE

--- a/app/src/main/res/layout/item_nearby_bus.xml
+++ b/app/src/main/res/layout/item_nearby_bus.xml
@@ -16,19 +16,12 @@
             android:id="@+id/NearbyBottomSheet_stopNickname"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:text="Stop Nickname"
+            android:textSize="16sp"
             />
         <TextView
-            android:id="@+id/NearbyBottomSheet_stopID"
+            android:id="@+id/NearbyBottomSheet_buses"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Stop ID"
-            />
-        <TextView
-            android:id="@+id/NearbyBottomSheet_stopUpcoming"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Upcoming Buses"
+            android:layout_height="match_parent"
             />
         <!-- Additional information and buttons -->
         <LinearLayout
@@ -37,10 +30,6 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:visibility="gone">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                />
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -51,7 +40,7 @@
                     android:id="@+id/save_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Add to Favourites" />
+                    android:text="@string/add_to_favourites" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="recycler_all_trips">All Trips</string>
     <string name="recycler_upcoming_trips">Upcoming Trips</string>
     <string name="recycler_active_trips">Active Trips</string>
+    <string name="add_to_favourites">Add to Favourites</string>
 </resources>


### PR DESCRIPTION
- change gtfs realtime to take in a list of stopid/routeid so that it only needs to make 1 api call instead of many
- cleanup nearbybottomsheet to get rid of stopid (not sure the user really cares about that), added stops to it, and moved around some text sizes
- cleaned up some warnings

i did NOT implement gtfs realtime data to each stop in the nearbystop page because when thinking about it, it doesn't make sense. if a bus stop has a lot of buses on it, then i'd have to show that many realtime bus stop data. 

![image](https://github.com/user-attachments/assets/1b0d685d-808a-49b8-80b6-e8a3dda14a2c)
