### PR TITLE
improve search feature 

### DIFF
--- a/app/src/main/java/ca/wheresthebus/MainDBViewModel.kt
+++ b/app/src/main/java/ca/wheresthebus/MainDBViewModel.kt
@@ -137,18 +137,15 @@ class MainDBViewModel : ViewModel() {
     // todo: can improve search by sorting by closest location
     fun searchForStop(input: String): List<BusStop> {
         // search the name parts by any matching string tokens
-        val words = input.split(" ").filter { it.isNotEmpty() }
-        val fuzzyQuery = List(words.size) { i ->
-            "(name CONTAINS[c] $${i + 1} OR ANY mongoRoutes.longName CONTAINS[c] $${i + 1})"
+        val tokens = input.split(" ").filter { it.isNotEmpty() }
+        val fuzzyQuery = List(tokens.size) { i ->
+            "(code == $${i} OR ANY mongoRoutes.shortName == $${i} OR name CONTAINS[c] $${i})"
         }.joinToString(" AND ")
 
-        // Strict search by code or route shortname
-        val query = "code == $0 OR ANY mongoRoutes.shortName == $0 OR ($fuzzyQuery)"
         val result = realm.query<MongoBusStop>(
-            query,
-            input,
-            *words.toTypedArray() // spread operator to pass string tokens as query params
-        ).find().take(10)
+            fuzzyQuery,
+            *tokens.toTypedArray() // spread operator to pass string tokens as query params
+        ).find().takeWhile { true }
 
         // Return result as a List<BusStops> instead of List<MongoBusStops>
         return result.map { modelFactory.toBusStop(it) }

--- a/app/src/main/java/ca/wheresthebus/ui/home/AddFavBottomSheet.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/home/AddFavBottomSheet.kt
@@ -123,7 +123,9 @@ class AddFavBottomSheet : BottomSheetDialogFragment() {
 
         // set dropdown content
         val routesAdapter =
-            ArrayAdapter(requireContext(), R.layout.route_spinner_item, routesMap.keys.toList())
+            ArrayAdapter(requireContext(), R.layout.route_spinner_item, routesMap.values.map {
+                "${it.shortName} - ${it.longName}"
+            })
         routesDropdown.setAdapter(routesAdapter)
 
         // Grab selected dropdown option
@@ -132,7 +134,8 @@ class AddFavBottomSheet : BottomSheetDialogFragment() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun afterTextChanged(s: Editable?) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                selectedRoute = routesMap[s.toString()]
+                // index routesMap using the shortname part of the dropdown content
+                selectedRoute = routesMap[s?.split(" - ")?.get(0)?.trim()]
             }
         })
 

--- a/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
+++ b/app/src/main/java/ca/wheresthebus/ui/nearby/NearbyStopsAdapter.kt
@@ -85,7 +85,9 @@ class NearbyStopsAdapter(
 
         // set dropdown content
         val routesAdapter =
-            ArrayAdapter(activity, R.layout.route_spinner_item, routesMap.keys.toList())
+            ArrayAdapter(activity, R.layout.route_spinner_item, routesMap.values.map {
+                "${it.shortName} - ${it.longName}"
+            })
         routesDropdown.setAdapter(routesAdapter)
 
         // Grab selected dropdown option
@@ -94,7 +96,8 @@ class NearbyStopsAdapter(
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun afterTextChanged(s: Editable?) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                selectedRoute = routesMap[s.toString()]
+                // index routesMap using the shortname part of the dropdown content
+                selectedRoute = routesMap[s?.split(" - ")?.get(0)?.trim()]
             }
         })
 


### PR DESCRIPTION
Removed the ability to search by route long name content because it would be confusing as to why a stop shows up in a list if no visible content matches the search. 

Instead, using the route.longName in the dialogue spinners to show more info during add to favourites. 

Also adds the ability to include a stop code or short name anywhere in a search input to match:
e.g. "street name 50003 33"
